### PR TITLE
Allow any afero-compliant FS to be used as dest

### DIFF
--- a/fsync.go
+++ b/fsync.go
@@ -213,7 +213,7 @@ func (s *Syncer) syncstats(dst, src string) {
 	// update dst's modification time
 	if !s.NoTimes {
 		if !dstat.ModTime().Equal(sstat.ModTime()) {
-			err := os.Chtimes(dst, sstat.ModTime(), sstat.ModTime())
+			err := s.DestFs.Chtimes(dst, sstat.ModTime(), sstat.ModTime())
 			check(err)
 		}
 	}


### PR DESCRIPTION
Using `os.Chtimes` instead of `s.DestFs.Chtimes` breaks cases where the destination FS isn't an OS filesystem (e.g. in-memory or S3).