### PR TITLE
Please merge upstream fixes for umask, permission and mtime

### DIFF
--- a/fsync.go
+++ b/fsync.go
@@ -207,7 +207,6 @@ func (s *Syncer) syncstats(dst, src string) {
 	// update dst's permission bits
 	if dstat.Mode().Perm() != sstat.Mode().Perm() {
 		check(s.DestFs.Chmod(dst, sstat.Mode().Perm()))
-		return
 	}
 
 	// update dst's modification time


### PR DESCRIPTION
Hello @spf13,

There has been a discussion on mostafah/fsync#5 about fsync_test.go failing in various corner cases, and one of which has to do with a left-behind `return` that left mtimes unsynchronized after syncing  permissions.  This led to the "FTBFS" (Fail To Build From Source) bug on the golang-github-spf13-fsync package as described at https://bugs.debian.org/802340.  It also manifested itself in spf13/hugo#1054.

The good news is that these bugs have been fixed in the upstream mostafah/fsync.  Please merge the recent upstream commits to spf13/fsync.

Please merge (or rebase?) directly from https://github.com/mostafah/fsync instead of merging this pull request—I seem to have created a rather ugly merge bubble myself, and I am sure you will have a better way of doing it.  :wink: