### PR TITLE
Added function to filter deletion of files in destination folder

### DIFF
--- a/fsync.go
+++ b/fsync.go
@@ -60,6 +60,9 @@ type Syncer struct {
 	// Set this to true to delete files in the destination that don't exist
 	// in the source.
 	Delete bool
+	// To allow certain files to remain in the destination, implement this function.
+	// Return true to skip file, false to delete.
+	DeleteFilter func(f os.FileInfo) bool
 	// By default, modification times are synced. This can be turned off by
 	// setting this to true.
 	NoTimes bool
@@ -74,7 +77,11 @@ type Syncer struct {
 
 // NewSyncer creates a new instance of Syncer with default options.
 func NewSyncer() *Syncer {
-	return &Syncer{SrcFs: new(afero.OsFs), DestFs: new(afero.OsFs)}
+	s := Syncer{SrcFs: new(afero.OsFs), DestFs: new(afero.OsFs)}
+	s.DeleteFilter = func(f os.FileInfo) bool {
+		return false
+	}
+	return &s
 }
 
 // Sync copies files and directories inside src into dst.
@@ -193,7 +200,7 @@ func (s *Syncer) sync(dst, src string) {
 		files, err = afero.ReadDir(s.DestFs, dst)
 		check(err)
 		for _, file := range files {
-			if !m[file.Name()] {
+			if !m[file.Name()] && !s.DeleteFilter(file) {
 				check(s.DestFs.RemoveAll(filepath.Join(dst, file.Name())))
 			}
 		}

--- a/fsync_test.go
+++ b/fsync_test.go
@@ -92,6 +92,79 @@ func TestSync(t *testing.T) {
 	}
 }
 
+func TestDeleteFileFilter(t *testing.T) {
+	// create test directory and chdir to it
+	dir, err := ioutil.TempDir(os.TempDir(), "fsync_test_delete_filter")
+	check(err)
+	check(os.Chdir(dir))
+
+	// create test files and directories
+	check(os.MkdirAll("src/a", 0755))
+	check(ioutil.WriteFile("src/a/b", []byte("file b"), 0644))
+
+	check(os.MkdirAll("dst", 0755))
+	check(ioutil.WriteFile("dst/c", []byte("file c"), 0644))
+	check(ioutil.WriteFile("dst/d", []byte("file c"), 0644))
+
+	// create Syncer
+	s := NewSyncer()
+	s.Delete = true
+
+	s.DeleteFilter = func(f os.FileInfo) bool {
+		if f.Name() == "d" {
+			return true
+		}
+		return false
+	}
+
+	//precondition; dst contains 2 files `c` and `d`
+	testDirContents("dst", 2, t)
+	testExistence("dst/c", true, t)
+	testExistence("dst/d", true, t)
+
+	check(s.Sync("dst", "src"))
+
+	// check results; c should no longer exist
+	testDirContents("dst", 2, t)
+	testExistence("dst/a/", true, t)
+	testExistence("dst/a/b", true, t)
+	testExistence("dst/c", false, t)
+	testExistence("dst/d", true, t)
+}
+
+func TestDeleteFileFilterNotSet(t *testing.T) {
+	// create test directory and chdir to it
+	dir, err := ioutil.TempDir(os.TempDir(), "fsync_test_delete_filter")
+	check(err)
+	check(os.Chdir(dir))
+
+	// create test files and directories
+	check(os.MkdirAll("src/a", 0755))
+	check(ioutil.WriteFile("src/a/b", []byte("file b"), 0644))
+
+	check(os.MkdirAll("dst", 0755))
+	check(ioutil.WriteFile("dst/c", []byte("file c"), 0644))
+	check(ioutil.WriteFile("dst/d", []byte("file c"), 0644))
+
+	// create Syncer
+	s := NewSyncer()
+	s.Delete = true
+
+	//precondition; dst contains 2 files `c` and `d`
+	testDirContents("dst", 2, t)
+	testExistence("dst/c", true, t)
+	testExistence("dst/d", true, t)
+
+	check(s.Sync("dst", "src"))
+
+	// check results; c should no longer exist
+	testDirContents("dst", 1, t)
+	testExistence("dst/a/", true, t)
+	testExistence("dst/a/b", true, t)
+	testExistence("dst/c", false, t)
+	testExistence("dst/d", false, t)
+}
+
 func testFile(name string, b []byte, t *testing.T) {
 	testExistence(name, true, t)
 	c, err := ioutil.ReadFile(name)


### PR DESCRIPTION
When deleting files in the destination folder, it is now possible to add a filter to allow some files to remain.

https://github.com/spf13/hugo/issues/3202